### PR TITLE
ci: fix prettier config to allow for rc file parsing

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "http://json.schemastore.org/prettierrc",
-	"overrides": [{ "files": ".nvmrc", "options": { "parser": "yaml" } }],
+	"overrides": [
+		{ "files": ".*rc", "options": { "parser": "json" } },
+		{ "files": ".nvmrc", "options": { "parser": "yaml" } }
+	],
 	"plugins": [
 		"prettier-plugin-curly",
 		"prettier-plugin-packagejson",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-fix-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-fix-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-fix-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This https://github.com/JoshuaKGoldberg/eslint-fix-utils/pull/10 revealed a gap in the prettier config.  This override adds parsing support for  rc files like the all-contributingrc
