### PR TITLE
fix: make `@types/estree` peer dependency optional

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://unpkg.com/knip@5.42.2/schema.json",
 	"entry": ["src/index.ts", "src/**/*.test.*"],
+	"ignoreDependencies": ["@types/estree"],
 	"ignoreExportsUsedInFile": { "interface": true, "type": true },
 	"project": ["src/**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
 		"@types/estree": ">=1",
 		"eslint": ">=8"
 	},
+	"peerDependenciesMeta": {
+		"@types/estree": {
+			"optional": true
+		}
+	},
 	"packageManager": "pnpm@9.15.3",
 	"engines": {
 		"node": ">=18.3.0"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #24
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-fix-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-fix-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I believe we still want to list the version resolution range to be informative to package managers that we need >=1.

💖 