### PR TITLE
ci: fix the release it config to only show user-facing changes

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -4,7 +4,6 @@
 		"requireCommits": true
 	},
 	"github": {
-		"autoGenerate": true,
 		"release": true,
 		"releaseName": "v${version}"
 	},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-fix-utils! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-fix-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-fix-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adjusts the release it config so that the output generated from the changelog plugin is used for the github release page.

Using autoGenerate overrides the output from the changelog plugin from making it onto the GH release.

Ref: https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/pull/789
