### PR TITLE
ci: adopt trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,14 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write # Required for ODIC
+
 concurrency:
   group: ${{ github.workflow }}
 
@@ -14,16 +25,5 @@ jobs:
       - run: pnpm build
       - env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: JoshuaKGoldberg/release-it-action@b3fd2b4b232338ac09c6ca8b587e6490f968a042 # v0.3.1
+        uses: JoshuaKGoldberg/release-it-action@8ee87d0d30f97b452ef5d8aa9f4d0490eed439aa # v0.4.0
 
-name: Release
-
-on:
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: write
-  id-token: write

--- a/.release-it.json
+++ b/.release-it.json
@@ -4,7 +4,9 @@
 		"requireCommits": true
 	},
 	"github": { "release": true, "releaseName": "v${version}" },
-	"npm": { "publishArgs": ["--access public", "--provenance"] },
+	"npm": {
+		"skipChecks": true
+	},
 	"plugins": {
 		"@release-it/conventional-changelog": {
 			"infile": "CHANGELOG.md",

--- a/package.json
+++ b/package.json
@@ -86,8 +86,5 @@
 	"packageManager": "pnpm@10.26.0",
 	"engines": {
 		"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-	},
-	"publishConfig": {
-		"provenance": true
 	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-fix-utils! 🔧
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #354
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-fix-utils/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-fix-utils/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change shifts to using trusted publisher. Provenance is automatically handled by the trusted publishing connection, without needing to enable it.
